### PR TITLE
Have interactive mode survive indent errors

### DIFF
--- a/powscript
+++ b/powscript
@@ -632,7 +632,7 @@ lint_pipe(){
   output="$(echo "$code" | awk -F"[  ]" '{ j=0; for(i=1;i<=NF && ($i=="");i++); j++; if( ((i-1)%2) != 0 ){ print "indent error: "$j" "$i; }  }')"
   if [[ ${#output} != 0 ]]; then
     echo "$output" 1>&2
-    exit 1
+    return 1
   else
     echo "$code"
     return 0

--- a/src/powscript.bash
+++ b/src/powscript.bash
@@ -219,7 +219,7 @@ lint_pipe(){
   output="$(echo "$code" | awk -F"[  ]" '{ j=0; for(i=1;i<=NF && ($i=="");i++); j++; if( ((i-1)%2) != 0 ){ print "indent error: "$j" "$i; }  }')"
   if [[ ${#output} != 0 ]]; then
     echo "$output" 1>&2
-    exit 1
+    return 1
   else
     echo "$code"
     return 0

--- a/test/interactive/error-handling.pow
+++ b/test/interactive/error-handling.pow
@@ -1,2 +1,5 @@
 ([
-echo 'I survived!'
+echo 'I survived an evaluation error!'
+
+ echo
+echo 'I survived an indent error!'


### PR DESCRIPTION
Missed this one until I experimented a bit with blocks.

I also noticed this:

``` bash
echo "
 x
"
```

Gives `indent error:  x`.

And this:

``` bash
echo "
if x
"
```

Transpiles to this:

``` bash
echo "
if x; then
fi
"
```

So I have that in my future.
