### PR TITLE
Fix escaping of ...tmp.$(whoami) in footer

### DIFF
--- a/.tools/runtests
+++ b/.tools/runtests
@@ -5,14 +5,14 @@ set -E
 export ErrorTracker=$(mktemp)
 echo "0" > $ErrorTracker
 
-NoIdent="_noIdent--##$RANDOM"
+NoIndent="_noIdent--##$RANDOM"
 
 format() {
   while IFS='' read -e -r line; do
-    if [[ ! "$line" =~ "$NoIdent".* ]]; then
+    if [[ ! "$line" =~ "$NoIndent".* ]]; then
       printf "  $line\n"
     else
-      printf "${line/$NoIdent/}\n"
+      printf "${line/$NoIndent/}\n"
     fi
   done
 }
@@ -28,46 +28,59 @@ Error="\033[1;31m"
 Nc="\033[0;00m"
 
 decl_file() {
-  printf "${NoIdent}${File}$1\n${Nc}"
+  printf "${NoIndent}${File}$1\n${Nc}"
 }
 
 checktest() {
-  if [ ! -x $2 ]; then
-    wait $!
+  if [ -n "$2" ]; then
+    wait "$2"
     local exitcode=$?
   else
     local exitcode=$1
   fi
   if [[ $exitcode == "0" ]]; then
-    printf "${NoIdent}${Pass}Tests passed!\n${Nc}\n"
+    printf "${NoIndent}${Pass}Tests passed!\n${Nc}\n"
   else
-    printf "${NoIdent}${Error}Tests failed!\n${Nc}\n"
+    printf "${NoIndent}${Error}Tests failed!\n${Nc}\n"
     exit 1
   fi
 }
 
 header() {
-  printf "${NoIdent}${Info}$1${Nc}\n"
+  printf "${NoIndent}${Info}$1${Nc}\n"
 }
 
-header "Compilation test:"
-./powscript --compile test/code-1.pow;
-checktest $? $! || exit 1
+finish() {
+  printf "${NoIndent}${Info}OK!${Nc}\n"
+}
+
+testdirectory() {
+  local directory="$1"
+  local command="$2"
+  local varname="$3"
+  local pattern="$4"
+  [[ ! -n $pattern ]] && pattern=".*"
+
+  for file in "$directory"/*; do
+    if [[ $file =~ $pattern ]]; then
+      decl_file "$file"
+      local rq_file="${file//\//\\/}"
+      eval "$(sed -E "s/\\\$[{]?${varname}[}]?/\"${rq_file}\"/" < <(echo "${command}"))"
+      checktest "$?" "$!" || exit 1
+    fi
+  done
+}
+
+header "Compilation tests:"
+testdirectory "test/compilation" './${file}' 'file'
 
 header "Evaluation tests:"
-for file in test/*.pow; do
-  decl_file "$file"
-  ./powscript $file
-  checktest $? $! || exit 1
-done
+testdirectory "test" './powscript ${file}' 'file' '.*\.pow$'
 
 header "Interactive mode tests:"
-for file in test/interactive/*.pow; do
-  decl_file "$file"
-  ./powscript --interactive < $file
-  checktest $? $! || exit 1
-done
-header 'OK'
+testdirectory "test/interactive" './powscript --interactive < ${file}' 'file'
+
+finish
 
 } | format
 

--- a/lang/bash/.util
+++ b/lang/bash/.util
@@ -6,8 +6,8 @@ footer["async"]="
 
 footer["tmpfile"]="
 # cleanup tmp files
-if ls /tmp/\$(basename \$0).tmp.$(whoami)* &>/dev/null; then
-  for f in /tmp/\$(basename \$0).tmp.$(whoami)*; do rm \$f; done
+if ls /tmp/\$(basename \$0).tmp.\$(whoami)* &>/dev/null; then
+  for f in /tmp/\$(basename \$0).tmp.\$(whoami)*; do rm \$f; done
 fi
 "
 footer["zero_exit"]="exit 0

--- a/powscript
+++ b/powscript
@@ -21,8 +21,8 @@ footer["async"]="
 
 footer["tmpfile"]="
 # cleanup tmp files
-if ls /tmp/\$(basename \$0).tmp.$(whoami)* &>/dev/null; then
-  for f in /tmp/\$(basename \$0).tmp.$(whoami)*; do rm \$f; done
+if ls /tmp/\$(basename \$0).tmp.\$(whoami)* &>/dev/null; then
+  for f in /tmp/\$(basename \$0).tmp.\$(whoami)*; do rm \$f; done
 fi
 "
 footer["zero_exit"]="exit 0

--- a/test/compilation/basic.bash
+++ b/test/compilation/basic.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./powscript --compile test/code-1.pow

--- a/test/compilation/whoami.bash
+++ b/test/compilation/whoami.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+Compiled="$(cat <(./powscript --compile <(echo "")))"
+[[ ! $Compiled =~ "tmp.$(whoami)" ]]
+


### PR DESCRIPTION
Also, in `runtests`:
- fix typo `Ident` -> `Indent`
- make more modular mechanism for testing directories
- separate compilation tests
