### PR TITLE
Fix error where "\$" became '\$'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powscript",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "bash dialect transpiler in bash: painless shellscript / indentbased / coffeescript for shellscript / bash for hipsters",
   "main": "powscript",
   "directories": {

--- a/powscript
+++ b/powscript
@@ -675,6 +675,7 @@ __shadowing_token:parse() {
           u)        token:parse-unicode-utf-16 e ; move=false ;;
           U)        token:parse-unicode-utf-32 e ; move=false ;;
           \\)       e='\' ;;
+          \$)       e='$' ;;
           *)        e="\\$c" ;;
         esac
         token+="$e"
@@ -6172,7 +6173,7 @@ powscript:help() {
   '
 }
 # FILE: compiler/helptext.bash
-POWSCRIPT_VERSION=1.1.1
+POWSCRIPT_VERSION=1.1.2
 
 version:number() {
   echo "$POWSCRIPT_VERSION"

--- a/src/lexer/lexer.bash
+++ b/src/lexer/lexer.bash
@@ -65,6 +65,7 @@ token:parse() { #<<NOSHADOW>>
           u)        token:parse-unicode-utf-16 e ; move=false ;;
           U)        token:parse-unicode-utf-32 e ; move=false ;;
           \\)       e='\' ;;
+          \$)       e='$' ;;
           *)        e="\\$c" ;;
         esac
         token+="$e"

--- a/test/strings/special-characters.pow
+++ b/test/strings/special-characters.pow
@@ -1,0 +1,4 @@
+assert "\\" is '\'
+assert "\a" is '\a'
+assert "\$" is '$'
+assert "%"  is '%'


### PR DESCRIPTION
Also test that `"\\"` becomes `'\'` and that `"%"` becomes `'%'` (the latter being a bug in the old powscript, as per https://github.com/coderofsalvation/powscript/pull/47.